### PR TITLE
Add bram readout

### DIFF
--- a/control/test/static/GARUD-react/src/App.jsx
+++ b/control/test/static/GARUD-react/src/App.jsx
@@ -8,6 +8,7 @@ import Main from "./MainPage";
 import GPIO_Direct from "./GPIODirect";
 import Configuration from "./Configuration";
 import Debug_Register from "./DebugRegister";
+import BRAM_View from "./BRAMView";
 import Sensor_Stimulus from "./SensorStimulus";
 import {
   getPulseGeneratorPageNames,
@@ -53,6 +54,7 @@ export default function App() {
           "Debug Register",
           "Sensor Stimulus",
           { "Pulse Generators": getPulseGeneratorPageNames(periodicEndpoint) },
+          "BRAM View",
           "Detector JSON",
           "Power Supply JSON",
         ]}
@@ -82,6 +84,9 @@ export default function App() {
           />
         </Container>
         {getPulseGeneratorPages(periodicEndpoint)}
+        <Container>
+          <BRAM_View periodicEndpoint={periodicEndpoint} />
+        </Container>
         <Container>
           <JSON_Display
             title={"Detector JSON Data"}

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -1,0 +1,154 @@
+import React from "react";
+import "bootstrap/dist/css/bootstrap.min.css";
+//import "odin-react/dist/index.css";
+import "./styles.css";
+import Plot from "react-plotly.js";
+import { TitleCard } from "odin-react";
+
+// a plotly component, to create a heatmap in black and white. The use of memo makes it only rerender when the isEqual function is false
+const Heatmap = React.memo((props) => {
+  return (
+    <Plot
+      data={[
+        {
+          showlegend: false,
+          showscale: false,
+          z: props.z_data,
+          type: "heatmap",
+          colorscale: "Greys",
+        },
+      ]}
+      config={{
+        responsive: true,
+      }}
+      layout={{
+        width:
+          window.innerWidth * 0.96 -
+          6.5 * parseFloat(getComputedStyle(document.documentElement).fontSize),
+        height:
+          window.innerWidth * 0.48 -
+          3.25 *
+            parseFloat(getComputedStyle(document.documentElement).fontSize),
+        margin: {
+          l: 10,
+          r: 10,
+          t: 10,
+          b: 10,
+        },
+        title: {
+          text: " ",
+        },
+        xaxis: {
+          visible: false,
+          fixedrange: true,
+        },
+        yaxis: {
+          visible: false,
+          fixedrange: true,
+        },
+      }}
+    />
+  );
+}, isEqual);
+
+// A function to evaluate if two arrays of data are the same, by converting them to strings and comparing them
+function isEqual(oldProps, newProps) {
+  return (
+    Array.from(oldProps.z_data).flat().join(",") ===
+    Array.from(newProps.z_data).flat().join(",")
+  );
+}
+
+function TriggerReadButton(props) {
+  function Send() {
+    //set the flag in the parameter tree to true to trigger a read
+    props.endpoint
+      .put({ [props.key]: true }, "application/bram/control")
+      .then((response) => {
+        props.endpoint.mergeData(response, "application/bram/control");
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+  return (
+    <input
+      style={{ width: "100%" }}
+      onClick={Send}
+      className="nice-button"
+      type="button"
+      value={props.name}
+    />
+  );
+}
+
+//convert the array of data we are given into a 2d array, then create a heatmap using the plotly library (component defined separately) using that data
+function BRAMFrameHeatmap(props) {
+  var z_data = [];
+  for (let x = 0; x < 64; x++) {
+    var temp = [];
+    for (let y = 0; y < 128; y++) {
+      temp.push(0);
+      //temp.push([0, 1][Math.floor(Math.random() * 2)]);
+    }
+    z_data.push(temp);
+  }
+  for (
+    let i = 0;
+    i < props.periodicEndpoint.data.application.bram.data[`frame${props.frame_number}`].length;
+    i++
+  ) {
+    z_data[63 - Math.floor(i / 128)][i % 128] =
+      props.periodicEndpoint.data.application.bram.data[`frame${props.frame_number}`][i];
+  }
+  return <Heatmap z_data={z_data} />;
+}
+
+export default function BRAM_View(props) {
+  return (
+    <div className="odin-server">
+      {Object.keys(props.periodicEndpoint.data).length > 0 ? (
+        <>
+          <TitleCard title="Trigger">
+            <div style={{ width: "49%", float: "left" }}>
+              <TitleCard title="Trigger Reads">
+                <div className="mytooltip">
+                  <TriggerReadButton
+                    endpoint={props.periodicEndpoint}
+                    key={"refresh"}
+                    name={"Refresh"}
+                  />
+                  {
+                    <span className="mytooltiptext">
+                      {"Function: _bram_refresh"}
+                    </span>
+                  }
+                </div>
+                <div style={{ width: "100%", height: "20px" }}></div>
+              </TitleCard>
+            </div>
+            <div style={{ width: "49%", float: "right" }}>
+              <TitleCard title="Read settings">
+              </TitleCard>
+            </div>
+          </TitleCard>
+          <br />
+          <TitleCard title="BRAM Output">
+            {props.periodicEndpoint.data.application.bram.data.frame0 != null ? (
+              <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={0} />
+            ) : (
+              <>
+                <p style={{ color: "red" }}>
+                  Error - no data received from garud detector adapter
+                </p>
+              </>
+            )}
+          </TitleCard>
+          <br />
+        </>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+}

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -169,22 +169,22 @@ function BRAMFrameHeatmap(props) {
   }
   for (
     let i = 0;
-    i < props.periodicEndpoint.data.application.bram.data[props.frame_number].length;
+    i < props.framedict[props.frame_number].length;
     i++
   ) {
     z_data[63 - Math.floor(i / 128)][i % 128] =
-      props.periodicEndpoint.data.application.bram.data[props.frame_number][i];
+      props.framedict[props.frame_number][i];
   }
   return <Heatmap z_data={z_data} />;
 }
 function BRAMFrames(props) {
     var framerows = [];
     for (let frame_number of Object.keys(props.periodicEndpoint.data.application.bram.data)) {
-        var title = props.periodicEndpoint.data.application.bram.control.display_combined ? "BRAM Combined frames  " + props.periodicEndpoint.data.application.bram.control.display_start_frame + " - " + props.periodicEndpoint.data.application.bram.control.display_num_frames : "BRAM Output frame " + frame_number;
+        var title = "BRAM Output frame " + frame_number;
         framerows.push(
           <TitleCard title={title}>
             {props.periodicEndpoint.data.application.bram.data[frame_number] != null ? (
-              <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={frame_number} />
+              <BRAMFrameHeatmap framedict={props.periodicEndpoint.data.application.bram.data} frame_number={frame_number} />
             ) : (
               <>
                 <p style={{ color: "red" }}>
@@ -196,6 +196,27 @@ function BRAMFrames(props) {
         );
     }
     return framerows;
+}
+
+function BRAMCombinedFrame(props) {
+    var title = "BRAM Combined frames  " + props.periodicEndpoint.data.application.bram.control.display_start_frame + " - " + (props.periodicEndpoint.data.application.bram.control.display_start_frame + props.periodicEndpoint.data.application.bram.control.display_num_frames);
+    if (props.periodicEndpoint.data.application.bram.control.display_combined) {
+        return (
+          <TitleCard title={title}>
+            {props.periodicEndpoint.data.application.bram.combined != null ? (
+              <BRAMFrameHeatmap framedict={props.periodicEndpoint.data.application.bram.combined} frame_number={0} />
+            ) : (
+              <>
+                <p style={{ color: "red" }}>
+                  Error - no data received from garud detector adapter
+                </p>
+              </>
+            )}
+          </TitleCard>
+        );
+    } else {
+        return (<></>);
+    }
 }
 
 export default function BRAM_View(props) {
@@ -243,6 +264,7 @@ export default function BRAM_View(props) {
             </div>
           </TitleCard>
           <br />
+          <BRAMCombinedFrame periodicEndpoint={props.periodicEndpoint} />
           <BRAMFrames periodicEndpoint={props.periodicEndpoint} />
           <br />
         </>

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -5,6 +5,80 @@ import "./styles.css";
 import Plot from "react-plotly.js";
 import { TitleCard } from "odin-react";
 
+function DisplayFrameStartInput(props) {
+  function Send(event, endpoint) {
+    endpoint
+      .put(
+        { ["display_start_frame"]: Number(event.target.value) },
+        "application/bram/control"
+      )
+      .then((response) => {
+        endpoint.mergeData(response, "application/bram/control");
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+  return (
+    <>
+      <div style={{ width: "100%" }}>
+        <p style={{ width: "240px", display: "inline-block" }}>
+          Starting frame (up to {props.periodicEndpoint.data.application.bram.control.max_frame}):
+        </p>
+        <input
+          onChange={(event) => Send(event, props.periodicEndpoint)}
+          className="DisplayFrameStartInput"
+          type="range"
+          min="0"
+          max={props.periodicEndpoint.data.application.bram.control.max_frame}
+        />
+        <p
+          style={{ width: "30px", marginLeft: "10px", display: "inline-block" }}
+        >
+          {props.periodicEndpoint.data.application.bram.control.display_start_frame}
+        </p>
+      </div>
+    </>
+  );
+}
+
+function DisplayFrameNumInput(props) {
+  function Send(event, endpoint) {
+    endpoint
+      .put(
+        { ["display_num_frames"]: Number(event.target.value) },
+        "application/bram/control"
+      )
+      .then((response) => {
+        endpoint.mergeData(response, "application/bram/control");
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+  return (
+    <>
+      <div style={{ width: "100%" }}>
+        <p style={{ width: "240px", display: "inline-block" }}>
+          Number of frames to display:
+        </p>
+        <input
+          onChange={(event) => Send(event, props.periodicEndpoint)}
+          className="DisplayFrameNumInput"
+          type="range"
+          min="1"
+          max={props.periodicEndpoint.data.application.bram.control.max_frame - props.periodicEndpoint.data.application.bram.control.display_start_frame}
+        />
+        <p
+          style={{ width: "30px", marginLeft: "10px", display: "inline-block" }}
+        >
+          {props.periodicEndpoint.data.application.bram.control.display_num_frames}
+        </p>
+      </div>
+    </>
+  );
+}
+
 // a plotly component, to create a heatmap in black and white. The use of memo makes it only rerender when the isEqual function is false
 const Heatmap = React.memo((props) => {
   return (
@@ -63,7 +137,7 @@ function TriggerReadButton(props) {
   function Send() {
     //set the flag in the parameter tree to true to trigger a read
     props.endpoint
-      .put({ [props.key]: true }, "application/bram/control")
+      .put({ ["refresh"]: true }, "application/bram/control")
       .then((response) => {
         props.endpoint.mergeData(response, "application/bram/control");
       })
@@ -106,8 +180,9 @@ function BRAMFrameHeatmap(props) {
 function BRAMFrames(props) {
     var framerows = [];
     for (let frame_number of Object.keys(props.periodicEndpoint.data.application.bram.data)) {
+        var title = props.periodicEndpoint.data.application.bram.control.display_combined ? "BRAM Combined frames  " + props.periodicEndpoint.data.application.bram.control.display_start_frame + " - " + props.periodicEndpoint.data.application.bram.control.display_num_frames : "BRAM Output frame " + frame_number;
         framerows.push(
-          <TitleCard title={"BRAM Output frame " + frame_number}>
+          <TitleCard title={title}>
             {props.periodicEndpoint.data.application.bram.data[frame_number] != null ? (
               <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={frame_number} />
             ) : (
@@ -134,7 +209,6 @@ export default function BRAM_View(props) {
                 <div className="mytooltip">
                   <TriggerReadButton
                     endpoint={props.periodicEndpoint}
-                    key={"refresh"}
                     name={"Refresh"}
                   />
                   {
@@ -148,6 +222,23 @@ export default function BRAM_View(props) {
             </div>
             <div style={{ width: "49%", float: "right" }}>
               <TitleCard title="Read settings">
+                <div className="mytooltip">
+                  <DisplayFrameStartInput periodicEndpoint={props.periodicEndpoint} />
+                  {
+                    <span className="mytooltiptext">
+                      {"Function: UPDATEME"}
+                    </span>
+                  }
+                </div>
+                <div style={{ width: "100%", height: "20px" }}></div>
+                <div className="mytooltip">
+                  <DisplayFrameNumInput periodicEndpoint={props.periodicEndpoint} />
+                  {
+                    <span className="mytooltiptext">
+                      {"Function: UPDATEME"}
+                    </span>
+                  }
+                </div>
               </TitleCard>
             </div>
           </TitleCard>

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -19,6 +19,10 @@ function DisplayFrameStartInput(props) {
         console.error(err);
       });
   }
+    function CheckInput(event, endpoint) {
+      console.log(event);
+      event.isTrusted && event.stopImmediatePropagation();
+    }
   return (
     <>
       <div style={{ width: "100%" }}>
@@ -26,7 +30,10 @@ function DisplayFrameStartInput(props) {
           Starting frame (up to {props.periodicEndpoint.data.application.bram.control.max_frame}):
         </p>
         <input
-          onChange={(event) => Send(event, props.periodicEndpoint)}
+          //onChange={(event) => console.log(event, props.periodicEndpoint)}
+          //onInput={(event) => CheckInput(event, props.periodicEndpoint)}
+          onSelect={(event) => Send(event, props.periodicEndpoint)}
+          onBlur={(event) => Send(event, props.periodicEndpoint)}
           className="DisplayFrameStartInput"
           type="range"
           min="0"
@@ -63,7 +70,9 @@ function DisplayFrameNumInput(props) {
           Number of frames to display:
         </p>
         <input
-          onChange={(event) => Send(event, props.periodicEndpoint)}
+          //onChange={(event) => Send(event, props.periodicEndpoint)}
+          onSelect={(event) => Send(event, props.periodicEndpoint)}
+          onBlur={(event) => Send(event, props.periodicEndpoint)}
           className="DisplayFrameNumInput"
           type="range"
           min="1"

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -200,7 +200,7 @@ function BRAMFrames(props) {
 
 function BRAMCombinedFrame(props) {
     var title = "BRAM Combined frames  " + props.periodicEndpoint.data.application.bram.control.display_start_frame + " - " + (props.periodicEndpoint.data.application.bram.control.display_start_frame + props.periodicEndpoint.data.application.bram.control.display_num_frames);
-    if (props.periodicEndpoint.data.application.bram.control.display_combined && Object.keys(props.periodicEndpoint.data.application.bram.combined) > 0) {
+    if (props.periodicEndpoint.data.application.bram.control.display_combined && (Object.keys(props.periodicEndpoint.data.application.bram.combined)).length > 0) {
         return (
           <TitleCard title={title}>
             {props.periodicEndpoint.data.application.bram.combined != null ? (

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -200,7 +200,7 @@ function BRAMFrames(props) {
 
 function BRAMCombinedFrame(props) {
     var title = "BRAM Combined frames  " + props.periodicEndpoint.data.application.bram.control.display_start_frame + " - " + (props.periodicEndpoint.data.application.bram.control.display_start_frame + props.periodicEndpoint.data.application.bram.control.display_num_frames);
-    if (props.periodicEndpoint.data.application.bram.control.display_combined) {
+    if (props.periodicEndpoint.data.application.bram.control.display_combined && Object.keys(props.periodicEndpoint.data.application.bram.combined) > 0) {
         return (
           <TitleCard title={title}>
             {props.periodicEndpoint.data.application.bram.combined != null ? (

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -103,6 +103,25 @@ function BRAMFrameHeatmap(props) {
   }
   return <Heatmap z_data={z_data} />;
 }
+function BRAMFrames(props) {
+    var framerows = [];
+    for (let frame_number of Object.keys(props.periodicEndpoint.data.application.bram.data)) {
+        framerows.push(
+          <TitleCard title={"BRAM Output frame " + frame_number}>
+            {props.periodicEndpoint.data.application.bram.data[frame_number] != null ? (
+              <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={frame_number} />
+            ) : (
+              <>
+                <p style={{ color: "red" }}>
+                  Error - no data received from garud detector adapter
+                </p>
+              </>
+            )}
+          </TitleCard>
+        );
+    }
+    return framerows;
+}
 
 export default function BRAM_View(props) {
   return (
@@ -133,17 +152,7 @@ export default function BRAM_View(props) {
             </div>
           </TitleCard>
           <br />
-          <TitleCard title={"BRAM Output frame " + props.periodicEndpoint.data.application.bram.control.display_start_frame}>
-            {props.periodicEndpoint.data.application.bram.control.display_start_frame != null ? (
-              <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={props.periodicEndpoint.data.application.bram.control.display_start_frame} />
-            ) : (
-              <>
-                <p style={{ color: "red" }}>
-                  Error - no data received from garud detector adapter
-                </p>
-              </>
-            )}
-          </TitleCard>
+          <BRAMFrames periodicEndpoint={props.periodicEndpoint} />
           <br />
         </>
       ) : (

--- a/control/test/static/GARUD-react/src/BRAMView.jsx
+++ b/control/test/static/GARUD-react/src/BRAMView.jsx
@@ -95,11 +95,11 @@ function BRAMFrameHeatmap(props) {
   }
   for (
     let i = 0;
-    i < props.periodicEndpoint.data.application.bram.data[`frame${props.frame_number}`].length;
+    i < props.periodicEndpoint.data.application.bram.data[props.frame_number].length;
     i++
   ) {
     z_data[63 - Math.floor(i / 128)][i % 128] =
-      props.periodicEndpoint.data.application.bram.data[`frame${props.frame_number}`][i];
+      props.periodicEndpoint.data.application.bram.data[props.frame_number][i];
   }
   return <Heatmap z_data={z_data} />;
 }
@@ -133,9 +133,9 @@ export default function BRAM_View(props) {
             </div>
           </TitleCard>
           <br />
-          <TitleCard title="BRAM Output">
-            {props.periodicEndpoint.data.application.bram.data.frame0 != null ? (
-              <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={0} />
+          <TitleCard title={"BRAM Output frame " + props.periodicEndpoint.data.application.bram.control.display_start_frame}>
+            {props.periodicEndpoint.data.application.bram.control.display_start_frame != null ? (
+              <BRAMFrameHeatmap periodicEndpoint={props.periodicEndpoint} frame_number={props.periodicEndpoint.data.application.bram.control.display_start_frame} />
             ) : (
               <>
                 <p style={{ color: "red" }}>


### PR DESCRIPTION
A blockram readout now shows the contents of blockram in a set number of frames.

There are mapped 64 'frames' worth of data in blockram, each stored as an array of 8192 bits (packed into 32-bit words). The UI now displays the contents of a configurable number of frames as a binary image in line with the display for the debug register slow readout.

In addition, it also shows the 'combined' frame, and optional stacked view of N frames together as they would be read out for true ADC readings.